### PR TITLE
Change mysql_real_escape string to $db->prepare_input

### DIFF
--- a/coinbasepp_callback.php
+++ b/coinbasepp_callback.php
@@ -31,7 +31,7 @@ if($type == "success") {
   }
   
   global $db;
-  $db->Execute("update ". TABLE_CONFIGURATION. " set configuration_value = '" . mysql_real_escape_string(serialize($tokens)) . "' where configuration_key = 'MODULE_PAYMENT_COINBASE_OAUTH'");
+  $db->Execute("update ". TABLE_CONFIGURATION. " set configuration_value = '" . $db->prepare_input(serialize($tokens)) . "' where configuration_key = 'MODULE_PAYMENT_COINBASE_OAUTH'");
   
   zen_redirect($hostPart . $_GET['after']);
 } else if($type == MODULE_PAYMENT_COINBASE_CALLBACK_SECRET) {

--- a/includes/modules/payment/coinbasepp.php
+++ b/includes/modules/payment/coinbasepp.php
@@ -85,7 +85,7 @@ class coinbasepp {
         $this->tokenFail($f->getMessage());
       }
       $coinbase = new Coinbase($oauth, $tokens);
-      $db->Execute("update ". TABLE_CONFIGURATION. " set configuration_value = '" . mysql_real_escape_string(serialize($tokens)) . "' where configuration_key = 'MODULE_PAYMENT_COINBASE_OAUTH'");
+      $db->Execute("update ". TABLE_CONFIGURATION. " set configuration_value = '" . $db->prepare_input(serialize($tokens)) . "' where configuration_key = 'MODULE_PAYMENT_COINBASE_OAUTH'");
 
       $code = $coinbase->createButton($name, $total, $currencyCode, $custom, $params)->button->code;
     }


### PR DESCRIPTION
This should resolve issues like the below, which currently occur during the plugin setup process.
`[xx-Nov-2014 00:xx:xx UTC] PHP Warning:  mysql_real_escape_string(): Access denied for user 'xx'@'xxxxxx' (using password: xx) in /home/xxx/public_html/store/coinbasepp_callback.php on line 34`
